### PR TITLE
raise error if document not found

### DIFF
--- a/lib/rails_admin/adapters/mongoid.rb
+++ b/lib/rails_admin/adapters/mongoid.rb
@@ -19,7 +19,9 @@ module RailsAdmin
       end
 
       def get(id)
-        AbstractObject.new(model.unscoped.find(id))
+        document = model.unscoped.find(id)
+        raise ::Mongoid::Errors::DocumentNotFound.new(model, id) unless document
+        AbstractObject.new(document)
       rescue => e
         raise e if %w(
           Mongoid::Errors::DocumentNotFound


### PR DESCRIPTION
This fix raises an error if the document is not found so that certain drop down menus in the admin can work.