### PR TITLE
GW-3524 #comment hidden fields for terminal.

### DIFF
--- a/app/views/rails_admin/main/edit.html.haml
+++ b/app/views/rails_admin/main/edit.html.haml
@@ -1,2 +1,14 @@
 = rails_admin_form_for @object, url: edit_path(@abstract_model, @object.id), as: @abstract_model.param_key, html: { method: "put", multipart: true, class: "form-horizontal denser", data: { title: @page_name } } do |form|
   = form.generate action: :update
+
+:javascript
+  $(function() {
+    if (location.pathname.startsWith('/admin/terminal/')) {
+      var adminId = $('.edit_user_root_link').children().attr('href').split('/')[3];
+      $('#terminal_updater').val(adminId);
+      console.log($('#terminal_updater').val());
+      $('#terminal_updater_field').hide();
+      $('#terminal_rails_admin').prop("checked", true);
+      $('#terminal_rails_admin_field').hide();
+    }
+  })


### PR DESCRIPTION
### This change is specific for Terminal
see http://jira.glooko.com:8080/browse/GW-3524
### implementation
set some fields' value in the HTML Form using JS and hide them to prevent user from changing it. These fields are used to know that the update is coming from RailsAdmin and to set the updater(admin id) automatically.